### PR TITLE
Fix udev rule quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ YAFI is also available on [Flathub](https://flathub.org/en/apps/au.stevetech.yaf
 
 ### Linux
 
-To allow YAFI to communicate with the EC, you will need to enable user access to the `/dev/cros_ec` device. You can do this by running `echo KERNEL=="cros_ec", TAG+="uaccess" | sudo tee /etc/udev/rules.d/60-yafi.rules`, and then reload the rules with `sudo udevadm control --reload-rules && sudo udevadm trigger`.
+To allow YAFI to communicate with the EC, you will need to enable user access to the `/dev/cros_ec` device. You can do this by running `echo KERNEL==\"cros_ec\", TAG+=\"uaccess\" | sudo tee /etc/udev/rules.d/60-yafi.rules`, and then reload the rules with `sudo udevadm control --reload-rules && sudo udevadm trigger`.
 
 You can also do this by running `curl -Lfs yafi.stevetech.au/udev.sh | sudo sh` which will run the [`add-udev-rules.sh`](add-udev-rules.sh) script.
 

--- a/add-udev-rules.sh
+++ b/add-udev-rules.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 echo Installing udev rules for YAFI to /etc/udev/rules.d/60-yafi.rules
-echo KERNEL=="cros_ec", TAG+="uaccess" > /etc/udev/rules.d/60-yafi.rules
+echo KERNEL==\"cros_ec\", TAG+=\"uaccess\" > /etc/udev/rules.d/60-yafi.rules
 udevadm control --reload-rules
 udevadm trigger
 echo udev rules installed successfully.


### PR DESCRIPTION
The udev rule doesn't properly install, because the quotes are removed at runtime when interpreted by BASH. 
```bash
$ echo KERNEL=="cros_ec", TAG+="uaccess"
KERNEL==cros_ec, TAG+=uaccess

$ echo KERNEL==\"cros_ec\", TAG+=\"uaccess\"
KERNEL=="cros_ec", TAG+="uaccess"
```